### PR TITLE
Fix error handling in httpserver.c

### DIFF
--- a/Core/Src/httpserver.c
+++ b/Core/Src/httpserver.c
@@ -461,25 +461,25 @@ static void httpserver_handle( void *pvParameters )
          etimeout++;                                                       
          break;    
       }
-      else if( lengthOfbytes == pdFREERTOS_ERRNO_ENOMEM )                                                                                        
+      else if( lengthOfbytes == -pdFREERTOS_ERRNO_ENOMEM )
       {                                                                                                                    
          // Error (maybe the connected socket already shut down the socket?). Attempt graceful shutdown.                   
          enomem++;                                                      
          break;
       } 
-      else if( lengthOfbytes == pdFREERTOS_ERRNO_ENOTCONN )                                                                   
+      else if( lengthOfbytes == -pdFREERTOS_ERRNO_ENOTCONN )
       {                                                                                                                       
          // Error (maybe the connected socket already shut down the socket?). Attempt graceful shutdown.                      
          enotconn++;                                                        
          break;
       } 
-      else if( lengthOfbytes == pdFREERTOS_ERRNO_EINTR )                                                                      
+      else if( lengthOfbytes == -pdFREERTOS_ERRNO_EINTR )
       {                                                                                                                       
          // Error (maybe the connected socket already shut down the socket?). Attempt graceful shutdown.                      
          eintr++;                                                        
          break;
       } 
-      else if( lengthOfbytes == pdFREERTOS_ERRNO_EINVAL )                                                                      
+      else if( lengthOfbytes == -pdFREERTOS_ERRNO_EINVAL )
       {                                                                                                                       
          // Error (maybe the connected socket already shut down the socket?). Attempt graceful shutdown.                      
          einval++;                                                          


### PR DESCRIPTION
pdFREERTOS_ERRNO_xxx defines is the positive numbers. They are returned instead of length of bytes. Internally they're returned with negative sign. Compare should also be with negative.